### PR TITLE
bugfix equal router prefix

### DIFF
--- a/client/views/School/CourseCreate/Container.jsx
+++ b/client/views/School/CourseCreate/Container.jsx
@@ -10,16 +10,11 @@ SchoolCourseCreate = createContainer(({ params }) => {
 
   const handles = {
     subjects: Meteor.subscribe('PublicSubjects'),
-    // tags: Meteor.subscribe('PublicTags'),
-    // users: Meteor.subscribe('AdminSchoolUsers', userId),
   };
 
   return {
     ready: _.mapValues(handles, h => h.ready()),
     subjects: Fetch.Public().subjects().fetch(),
-    // tags: Fetch.Public().tags().fetch(),
-    // students: Fetch.School(schoolId).students().fetch(),
-    // teachers: Fetch.School(schoolId).teachers().fetch(),
   };
 
 }, SchoolCourseCreateView);

--- a/packages/se-router/lib/admin.jsx
+++ b/packages/se-router/lib/admin.jsx
@@ -100,7 +100,7 @@ adminRoutes.route('/planos/novo', {
   },
 });
 
-adminRoutes.route('/planos/:planId', {
+adminRoutes.route('/plano/:planId', {
   name: 'AdminPlan',
   action(params) {
     render({

--- a/packages/se-router/lib/school.jsx
+++ b/packages/se-router/lib/school.jsx
@@ -24,7 +24,7 @@ schoolRoutes.route('/cursos', {
   },
 });
 
-schoolRoutes.route('/cursos/:courseId', {
+schoolRoutes.route('/curso/:courseId', {
   name: 'SchoolCourse',
   action(params) {
     render({


### PR DESCRIPTION
As rotas do flowrouter não podem ter um prefixo igual, pois o parâmetro que estava sendo passado era a string `'novo'` como parâmetro para `courseId`